### PR TITLE
Update to 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.diabolicallabs</groupId>
     <artifactId>vertx-cron</artifactId>
     <packaging>jar</packaging>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.4.2-SNAPSHOT</version>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -46,8 +46,7 @@
 
     <properties>
         <main.verticle>com.diabolicallabs.vertx.cron.CronEventSchedulerVertical</main.verticle>
-        <vertx.version>3.3.0</vertx.version>
-        <hazelcast.version>3.6</hazelcast.version>
+        <vertx.version>3.4.2</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Hi all,

thank you for this project! I just upgraded to vertx 3.4.2 and needed this dependancy to be on vertx 3.4.2, too. It seems the only necessity is to bump the vertx version in the maven pom file. Scheduled cron jobs work as they did before.

Tadaa.