### PR TITLE
updated to vertx 3.8.3 and fixed deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the consumer completes. You can also cancel the scheduled event at a future time
 
 It also provides an RxJava Observable for use with Vert.x Rx.
 
-Tested with Eclipse Vert.x 3.5.0
+Tested with Eclipse Vert.x 3.8.3
 
 ## Event Bus Cron Scheduler
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.diabolicallabs</groupId>
     <artifactId>vertx-cron</artifactId>
     <packaging>jar</packaging>
-    <version>3.7.2-SNAPSHOT</version>
+    <version>3.8.3-SNAPSHOT</version>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -46,7 +46,7 @@
 
     <properties>
         <main.verticle>com.diabolicallabs.vertx.cron.CronEventSchedulerVertical</main.verticle>
-        <vertx.version>3.7.1</vertx.version>
+        <vertx.version>3.8.3</vertx.version>
     </properties>
 
     <dependencies>
@@ -129,6 +129,7 @@
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
+                        <showDeprecation>true</showDeprecation>
                         <generatedSourcesDirectory>
                             ${project.basedir}/src/main/generated
                         </generatedSourcesDirectory>

--- a/src/main/java/com/diabolicallabs/vertx/cron/CronEventSchedulerVertical.java
+++ b/src/main/java/com/diabolicallabs/vertx/cron/CronEventSchedulerVertical.java
@@ -2,6 +2,7 @@ package com.diabolicallabs.vertx.cron;
 
 import io.reactivex.Scheduler;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -20,7 +21,7 @@ public class CronEventSchedulerVertical extends AbstractVerticle {
   Logger logger = LoggerFactory.getLogger(this.getClass());
 
   @Override
-  public void start(Future<Void> startFuture) throws Exception {
+  public void start(Promise<Void> startFuture) throws Exception {
 
     EventBus eb = vertx.eventBus();
 
@@ -97,7 +98,7 @@ public class CronEventSchedulerVertical extends AbstractVerticle {
         .subscribe(
           timestamped -> {
             if (action.equals("send")) {
-              eb.send(scheduledAddress, scheduledMessage, scheduledAddressHandler -> {
+              eb.request(scheduledAddress, scheduledMessage, scheduledAddressHandler -> {
                 if (resultAddress != null) {
                   if (scheduledAddressHandler.succeeded()) {
                     eb.send(resultAddress, scheduledAddressHandler.result().body());

--- a/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusAlternateBaseTest.java
+++ b/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusAlternateBaseTest.java
@@ -46,8 +46,8 @@ public class CronEventBusAlternateBaseTest {
       gotit.set(true);
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
-      if (handler.failed()) context.fail(handler.cause());
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
+        if (handler.failed()) context.fail(handler.cause());
     });
 
     rule.vertx().setTimer(1000 * 2, timerHandler -> {

--- a/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusTest.java
+++ b/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusTest.java
@@ -68,7 +68,7 @@ public class CronEventBusTest {
       gotit.set(true);
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
 
@@ -92,7 +92,7 @@ public class CronEventBusTest {
       gotit.set(true);
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
 
@@ -137,7 +137,7 @@ public class CronEventBusTest {
     });
 
     DeliveryOptions options = new DeliveryOptions().setSendTimeout(threeMinutes);
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, options, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, options, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
 
@@ -161,7 +161,7 @@ public class CronEventBusTest {
       got2.set(true);
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
 
@@ -191,7 +191,7 @@ public class CronEventBusTest {
       async.complete();
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
   }
@@ -216,7 +216,7 @@ public class CronEventBusTest {
       async.complete();
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
   }
@@ -251,7 +251,7 @@ public class CronEventBusTest {
       });
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       id.set((String) handler.result().body());
       System.out.println("Id: " + id.get());
       if (handler.failed()) context.fail(handler.cause());
@@ -289,7 +289,7 @@ public class CronEventBusTest {
       });
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       id.set((String) handler.result().body());
       System.out.println("Id: " + id.get());
       if (handler.failed()) context.fail(handler.cause());
@@ -309,7 +309,7 @@ public class CronEventBusTest {
       gotit.set(true);
     });
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.failed()) context.fail(handler.cause());
     });
 
@@ -327,7 +327,7 @@ public class CronEventBusTest {
     JsonObject event = event();
     event.remove("cron_expression");
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.succeeded()) context.fail("Should have failed due to bad cronspec");
       if (handler.failed()) {
         context.assertEquals("Message must contain cron_expression", handler.cause().getMessage());
@@ -344,7 +344,7 @@ public class CronEventBusTest {
     JsonObject event = event();
     event.remove("address");
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.succeeded()) context.fail("Should have failed due to bad cronspec");
       if (handler.failed()) {
         context.assertEquals("Message must contain the address to schedule", handler.cause().getMessage());
@@ -360,7 +360,7 @@ public class CronEventBusTest {
 
     JsonObject event = event().put("timezone_name", "USSR/Honolulu");
 
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.succeeded()) context.fail("Should have failed due to bad timezone");
       if (handler.failed()) {
         context.assertEquals("timezone_name USSR/Honolulu is invalid", handler.cause().getMessage());
@@ -375,7 +375,7 @@ public class CronEventBusTest {
     Async async = context.async();
 
     JsonObject event = event().put("cron_expression", "SQUID");
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.succeeded()) context.fail("Should have failed due to bad cronspec");
       if (handler.failed()) {
         context.assertEquals("Invalid cronspec SQUID", handler.cause().getMessage());
@@ -390,7 +390,7 @@ public class CronEventBusTest {
     Async async = context.async();
 
     JsonObject event = event().put("action", "SQUID");
-    rule.vertx().eventBus().send(BASE_ADDRESS, event, handler -> {
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, handler -> {
       if (handler.succeeded()) context.fail("Should have failed due to bad action");
       if (handler.failed()) {
         context.assertEquals("action must be 'send' or 'publish'", handler.cause().getMessage());


### PR DESCRIPTION
Updated to latest version of Vertx 3.8.3
Sometimes testDoubleCancel Test fails, I am not sure what is causing this issue.