### PR TITLE
Add local-only delivery configuration

### DIFF
--- a/src/main/java/com/diabolicallabs/vertx/cron/CronEventSchedulerVertical.java
+++ b/src/main/java/com/diabolicallabs/vertx/cron/CronEventSchedulerVertical.java
@@ -3,6 +3,7 @@ package com.diabolicallabs.vertx.cron;
 import io.reactivex.Scheduler;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -75,6 +76,7 @@ public class CronEventSchedulerVertical extends AbstractVerticle {
       Object scheduledMessage = message.getValue("message");
       String action = message.getString("action", "send");
       String resultAddress = message.getString("result_address");
+      Boolean localOnly = message.getBoolean("local_only", false);
 
       SharedData sd = vertx.sharedData();
       String id;
@@ -97,11 +99,12 @@ public class CronEventSchedulerVertical extends AbstractVerticle {
         })
         .subscribe(
           timestamped -> {
+            DeliveryOptions deliveryOptions = new DeliveryOptions().setLocalOnly(localOnly);
             if (action.equals("send")) {
               eb.request(scheduledAddress, scheduledMessage, scheduledAddressHandler -> {
                 if (resultAddress != null) {
                   if (scheduledAddressHandler.succeeded()) {
-                    eb.send(resultAddress, scheduledAddressHandler.result().body());
+                    eb.send(resultAddress, scheduledAddressHandler.result().body(), deliveryOptions);
                   } else {
                     if (scheduledAddressHandler.failed()) {
                       logger.error("Message to " + resultAddress + " failed.", scheduledAddressHandler.cause());
@@ -110,7 +113,7 @@ public class CronEventSchedulerVertical extends AbstractVerticle {
                 }
               });
             } else {
-              eb.publish(scheduledAddress, scheduledMessage);
+              eb.publish(scheduledAddress, scheduledMessage, deliveryOptions);
             }
           },
           fault -> {

--- a/src/main/java/com/diabolicallabs/vertx/cron/CronEventSchedulerVertical.java
+++ b/src/main/java/com/diabolicallabs/vertx/cron/CronEventSchedulerVertical.java
@@ -101,10 +101,10 @@ public class CronEventSchedulerVertical extends AbstractVerticle {
           timestamped -> {
             DeliveryOptions deliveryOptions = new DeliveryOptions().setLocalOnly(localOnly);
             if (action.equals("send")) {
-              eb.request(scheduledAddress, scheduledMessage, scheduledAddressHandler -> {
+              eb.request(scheduledAddress, scheduledMessage, deliveryOptions, scheduledAddressHandler -> {
                 if (resultAddress != null) {
                   if (scheduledAddressHandler.succeeded()) {
-                    eb.send(resultAddress, scheduledAddressHandler.result().body(), deliveryOptions);
+                    eb.send(resultAddress, scheduledAddressHandler.result().body());
                   } else {
                     if (scheduledAddressHandler.failed()) {
                       logger.error("Message to " + resultAddress + " failed.", scheduledAddressHandler.cause());

--- a/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusTest.java
+++ b/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusTest.java
@@ -452,14 +452,14 @@ public class CronEventBusTest {
 
     String address = UUID.randomUUID().toString();
     // Make sure the action to set to send. We'll have to send several triggers to make sure they
-    // are all sent to the first vertx instance.
+    // are all sent to the first and only the first vertx instance.
     JsonObject event = event().put("address", address).put("action", "send").put("local_only", true);
 
     // Add a trigger count to the first vertx instance, to track the number of received triggers.
     AtomicInteger triggerCount1 = new AtomicInteger(0);
     rule.vertx().eventBus().consumer(address, handler -> triggerCount1.incrementAndGet());
 
-    // Add a trigger count to the first vertx instance, to track the number of received triggers.
+    // Add a trigger count to the second vertx instance, to track the number of received triggers.
     AtomicInteger triggerCount2 = new AtomicInteger(0);
     rule2.vertx().eventBus().consumer(address, handler -> triggerCount2.incrementAndGet());
 

--- a/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusTest.java
+++ b/src/test/java/com/diabolicallabs/test/vertx/cron/CronEventBusTest.java
@@ -330,7 +330,7 @@ public class CronEventBusTest {
    * property is false.
    */
   @Test
-  public void testSendWithoutLocalOnly(TestContext context) {
+  public void testPublishWithoutLocalOnly(TestContext context) {
 
     Async async = context.async();
 
@@ -366,7 +366,7 @@ public class CronEventBusTest {
   }
 
   @Test
-  public void testSendWithLocalOnlyFalse(TestContext context) {
+  public void testPublishWithLocalOnlyFalse(TestContext context) {
 
     Async async = context.async();
 
@@ -402,7 +402,7 @@ public class CronEventBusTest {
   }
 
   @Test
-  public void testSendWithLocalOnlyTrue(TestContext context) {
+  public void testPublishWithLocalOnlyTrue(TestContext context) {
 
     Async async = context.async();
 
@@ -435,6 +435,46 @@ public class CronEventBusTest {
       context.assertTrue(gotit1.get());
       // Assert that the second vertx instance did not receive the trigger.
       context.assertFalse(gotit2.get());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void testSendWithLocalOnlyTrue(TestContext context) {
+
+    Async async = context.async();
+
+    // Deploy a second vertx instance to the cluster, to test that only one instance receives the
+    // trigger (i.e. the trigger is only sent locally).
+    rule2.vertx().deployVerticle(CronEventSchedulerVertical.class.getName(), context.asyncAssertSuccess(id -> {
+      System.out.println("CronEventSchedulerVertical2 deployment id: " + id);
+    }));
+
+    String address = UUID.randomUUID().toString();
+    // Make sure the action to set to send. We'll have to send several triggers to make sure they
+    // are all sent to the first vertx instance.
+    JsonObject event = event().put("address", address).put("action", "send").put("local_only", true);
+
+    // Add a trigger count to the first vertx instance, to track the number of received triggers.
+    AtomicInteger triggerCount1 = new AtomicInteger(0);
+    rule.vertx().eventBus().consumer(address, handler -> triggerCount1.incrementAndGet());
+
+    // Add a trigger count to the first vertx instance, to track the number of received triggers.
+    AtomicInteger triggerCount2 = new AtomicInteger(0);
+    rule2.vertx().eventBus().consumer(address, handler -> triggerCount2.incrementAndGet());
+
+    // Send the schedule request to the first vertx instance. This instance is expected to be the
+    // only instance to receive the resulting triggers.
+    rule.vertx().eventBus().request(BASE_ADDRESS, event, new DeliveryOptions().setLocalOnly(true), handler -> {
+      if (handler.failed()) context.fail(handler.cause());
+    });
+
+    rule.vertx().setTimer((long) (1000 * 10.5), timerHandler -> {
+      System.out.println("Trigger count 2: " + triggerCount2);
+      // Assert that the first vertx instance received every trigger.
+      context.assertEquals(10, triggerCount1.get());
+      // Assert that the second vertx instance did not receive any triggers.
+      context.assertEquals(0, triggerCount2.get());
       async.complete();
     });
   }


### PR DESCRIPTION
This adds the functionality to have schedules only send triggers locally (within their own vertx instance), instead of across the entire cluster.

The need for this feature arises from a project we are developing that runs on multiple instances in the same cluster. In this case, there is no master instance that can be relied on to run all schedules. Any instance on the cluster must be able to be torn down at any moment without killing any schedules. To facilitate this, all instances must be running the same schedules. Preventing multiple executions of the same trigger is easy enough (using `vertx.sharedData()`), but only if each instance's schedule is sending its triggers to its own instance. Currently, a schedule running on one instance can send its trigger to another instance. This creates a problem when a single instance is receiving multiple other instances' triggers all at once while other instances are not receiving any triggers. This features ensure that each instance will receive its own trigger and only its own trigger, if configured.